### PR TITLE
Feat/stable id algorithm maplockjson

### DIFF
--- a/manifest/src/main/java/io/pulseautomate/map/manifest/id/StableId.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/id/StableId.java
@@ -1,0 +1,26 @@
+package io.pulseautomate.map.manifest.id;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.Objects;
+
+public final class StableId {
+    private StableId() {}
+
+    public static String derive(String seed) {
+        Objects.requireNonNull(seed, "seed");
+        var bytes = sha256(seed);
+        var hex = HexFormat.of().formatHex(bytes);
+        return "stable: " + hex.substring(0, 12);
+    }
+
+    private static byte[] sha256(String s) {
+        try {
+            var md = MessageDigest.getInstance("SHA-256");
+            return md.digest(s.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new RuntimeException("SHA-256 not available", e);
+        }
+    }
+}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/id/StableId.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/id/StableId.java
@@ -1,18 +1,21 @@
 package io.pulseautomate.map.manifest.id;
 
+import io.pulseautomate.map.manifest.util.Hashing;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.util.HexFormat;
 import java.util.Objects;
+
+import static io.pulseautomate.map.manifest.util.Constants.STABLE_ID_HEX_LENGTH;
+import static io.pulseautomate.map.manifest.util.Constants.STABLE_PREFIX;
 
 public final class StableId {
   private StableId() {}
 
   public static String derive(String seed) {
     Objects.requireNonNull(seed, "seed");
-    var bytes = sha256(seed);
-    var hex = HexFormat.of().formatHex(bytes);
-    return "stable: " + hex.substring(0, 12);
+    var hex = Hashing.sha256Hex(seed);
+    return STABLE_PREFIX + hex.substring(0, STABLE_ID_HEX_LENGTH);
   }
 
   private static byte[] sha256(String s) {

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/id/StableId.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/id/StableId.java
@@ -6,21 +6,21 @@ import java.util.HexFormat;
 import java.util.Objects;
 
 public final class StableId {
-    private StableId() {}
+  private StableId() {}
 
-    public static String derive(String seed) {
-        Objects.requireNonNull(seed, "seed");
-        var bytes = sha256(seed);
-        var hex = HexFormat.of().formatHex(bytes);
-        return "stable: " + hex.substring(0, 12);
-    }
+  public static String derive(String seed) {
+    Objects.requireNonNull(seed, "seed");
+    var bytes = sha256(seed);
+    var hex = HexFormat.of().formatHex(bytes);
+    return "stable: " + hex.substring(0, 12);
+  }
 
-    private static byte[] sha256(String s) {
-        try {
-            var md = MessageDigest.getInstance("SHA-256");
-            return md.digest(s.getBytes(StandardCharsets.UTF_8));
-        } catch (Exception e) {
-            throw new RuntimeException("SHA-256 not available", e);
-        }
+  private static byte[] sha256(String s) {
+    try {
+      var md = MessageDigest.getInstance("SHA-256");
+      return md.digest(s.getBytes(StandardCharsets.UTF_8));
+    } catch (Exception e) {
+      throw new RuntimeException("SHA-256 not available", e);
     }
+  }
 }

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/id/StableId.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/id/StableId.java
@@ -1,13 +1,12 @@
 package io.pulseautomate.map.manifest.id;
 
-import io.pulseautomate.map.manifest.util.Hashing;
+import static io.pulseautomate.map.manifest.util.Constants.STABLE_ID_HEX_LENGTH;
+import static io.pulseautomate.map.manifest.util.Constants.STABLE_PREFIX;
 
+import io.pulseautomate.map.manifest.util.Hashing;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Objects;
-
-import static io.pulseautomate.map.manifest.util.Constants.STABLE_ID_HEX_LENGTH;
-import static io.pulseautomate.map.manifest.util.Constants.STABLE_PREFIX;
 
 public final class StableId {
   private StableId() {}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockBuilder.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockBuilder.java
@@ -1,5 +1,7 @@
 package io.pulseautomate.map.manifest.lock;
 
+import static io.pulseautomate.map.manifest.util.Constants.*;
+
 import io.pulseautomate.map.manifest.id.StableId;
 import io.pulseautomate.map.manifest.model.Entity;
 import io.pulseautomate.map.manifest.model.Manifest;
@@ -7,14 +9,9 @@ import io.pulseautomate.map.manifest.model.Service;
 import io.pulseautomate.map.manifest.serde.ManifestCanonicalizer;
 import io.pulseautomate.map.manifest.serde.ManifestJson;
 import io.pulseautomate.map.manifest.util.Hashing;
-
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-
-import static io.pulseautomate.map.manifest.util.Constants.*;
 
 public final class LockBuilder {
   private LockBuilder() {}
@@ -102,7 +99,11 @@ public final class LockBuilder {
               });
     }
 
-    return s.domain() + "." + s.service() + SIG_MAIN_SEP + String.join(String.valueOf(SIG_FIELD_SEP), fields);
+    return s.domain()
+        + "."
+        + s.service()
+        + SIG_MAIN_SEP
+        + String.join(String.valueOf(SIG_FIELD_SEP), fields);
   }
 
   private static String nullToEmpty(String s) {

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockBuilder.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockBuilder.java
@@ -1,0 +1,139 @@
+package io.pulseautomate.map.manifest.lock;
+
+import io.pulseautomate.map.manifest.id.StableId;
+import io.pulseautomate.map.manifest.model.Entity;
+import io.pulseautomate.map.manifest.model.Manifest;
+import io.pulseautomate.map.manifest.model.Service;
+import io.pulseautomate.map.manifest.serde.ManifestCanonicalizer;
+import io.pulseautomate.map.manifest.serde.ManifestJson;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+public final class LockBuilder {
+    private LockBuilder() {}
+
+    public static LockFile build(Manifest manifest, LockFile previous, Instant nowUtc) {
+        Objects.requireNonNull(manifest, "manifest");
+        Objects.requireNonNull(nowUtc, "nowUtc");
+
+        var manifestHash = sha256Hex(serialise(manifest));
+
+        Map<String, String> entityMap = new LinkedHashMap<>();
+        Map<String, String> prevMap = previous != null && previous.entity_map() != null
+                ? previous.entity_map() : Map.of();
+
+        for(Entity e : ManifestCanonicalizer.canonicalize(manifest).entities()) {
+            var stable = e.stable_id();
+            if(stable == null || stable.isBlank())
+                stable = prevMap.get(e.entity_id());
+
+            if(stable == null || stable.isBlank())
+                stable = StableId.derive(e.entity_id());
+
+            entityMap.put(e.entity_id(), stable);
+        }
+
+        Map<String, String> serviceSig = new LinkedHashMap<>();
+        for (Service s : ManifestCanonicalizer.canonicalize(manifest).services()) {
+            var key = s.domain() + "." + s.service();
+            var shape = signatureShape(s);
+            serviceSig.put(key, sha256Hex(shape));
+        }
+
+        Map<String, List<String>> attrEnums = new LinkedHashMap<>();
+        for (Entity e : ManifestCanonicalizer.canonicalize(manifest).entities()) {
+            if (e.attributes() == null) continue;
+            for (var entry : e.attributes().entrySet()) {
+                var attr = entry.getKey();
+                var desc = entry.getValue();
+
+                if (desc.enumValues() == null || desc.enumValues().isEmpty()) continue;
+                var key = e.domain() + "." + attr;
+                var list = attrEnums.computeIfAbsent(key, k -> new ArrayList<>());
+                list.addAll(desc.enumValues());
+            }
+        }
+
+        for (var it : attrEnums.entrySet()) {
+            List<String> uniqSorted = it.getValue().stream()
+                    .distinct()
+                    .sorted()
+                    .toList();
+            it.setValue(uniqSorted);
+        }
+
+        return new LockFile(
+                1,
+                manifestHash,
+                DateTimeFormatter.ISO_INSTANT.format(nowUtc),
+                entityMap,
+                serviceSig,
+                attrEnums.isEmpty() ? null : attrEnums
+        );
+    }
+
+    private static String serialise(Manifest m) {
+        try {
+            return ManifestJson.toPrettyString(ManifestCanonicalizer.canonicalize(m));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialise manifest", e);
+        }
+    }
+
+    private static String signatureShape(Service s) {
+        var fields = new ArrayList<String>();
+
+        if(s.fields() != null) {
+            s.fields().entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(e -> {
+                        var serviceField = e.getValue();
+                        var sb = new StringBuilder();
+
+                        sb.append(e.getKey())
+                                .append(":")
+                                .append(nullToEmpty(serviceField.type()));
+
+                        if(Boolean.TRUE.equals(serviceField.required())) sb.append(":req");
+                        if(serviceField.unit() != null && !serviceField.unit().isBlank())
+                            sb.append(":").append(serviceField.unit());
+
+                        fields.add(sb.toString());
+                    });
+        }
+
+        return s.domain() + "." + s.service() + "|" + String.join("|", fields);
+    }
+
+    private static String sha256Hex(String s) {
+        try {
+            var md = MessageDigest.getInstance("SHA-256");
+            var d = md.digest(s.getBytes(StandardCharsets.UTF_8));
+            return Hex.of(d);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final class Hex {
+        private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+        static String of(byte[] b) {
+            var out = new char[b.length * 2];
+            for (int i = 0, j = 0; i < b.length; i++) {
+                var v = b[i] & 0xFF;
+                out[j++] = HEX[v >> 4];
+                out[j++] = HEX[v & 0x0f];
+            }
+            return new String(out);
+        }
+    }
+
+    private static String nullToEmpty(String s) {
+        return s == null ? "" : s;
+    }
+}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockBuilder.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockBuilder.java
@@ -6,7 +6,6 @@ import io.pulseautomate.map.manifest.model.Manifest;
 import io.pulseautomate.map.manifest.model.Service;
 import io.pulseautomate.map.manifest.serde.ManifestCanonicalizer;
 import io.pulseautomate.map.manifest.serde.ManifestJson;
-
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Instant;
@@ -14,126 +13,119 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 public final class LockBuilder {
-    private LockBuilder() {}
+  private LockBuilder() {}
 
-    public static LockFile build(Manifest manifest, LockFile previous, Instant nowUtc) {
-        Objects.requireNonNull(manifest, "manifest");
-        Objects.requireNonNull(nowUtc, "nowUtc");
+  public static LockFile build(Manifest manifest, LockFile previous, Instant nowUtc) {
+    Objects.requireNonNull(manifest, "manifest");
+    Objects.requireNonNull(nowUtc, "nowUtc");
 
-        var manifestHash = sha256Hex(serialise(manifest));
+    var manifestHash = sha256Hex(serialise(manifest));
 
-        Map<String, String> entityMap = new LinkedHashMap<>();
-        Map<String, String> prevMap = previous != null && previous.entity_map() != null
-                ? previous.entity_map() : Map.of();
+    Map<String, String> entityMap = new LinkedHashMap<>();
+    Map<String, String> prevMap =
+        previous != null && previous.entity_map() != null ? previous.entity_map() : Map.of();
 
-        for(Entity e : ManifestCanonicalizer.canonicalize(manifest).entities()) {
-            var stable = e.stable_id();
-            if(stable == null || stable.isBlank())
-                stable = prevMap.get(e.entity_id());
+    for (Entity e : ManifestCanonicalizer.canonicalize(manifest).entities()) {
+      var stable = e.stable_id();
+      if (stable == null || stable.isBlank()) stable = prevMap.get(e.entity_id());
 
-            if(stable == null || stable.isBlank())
-                stable = StableId.derive(e.entity_id());
+      if (stable == null || stable.isBlank()) stable = StableId.derive(e.entity_id());
 
-            entityMap.put(e.entity_id(), stable);
-        }
-
-        Map<String, String> serviceSig = new LinkedHashMap<>();
-        for (Service s : ManifestCanonicalizer.canonicalize(manifest).services()) {
-            var key = s.domain() + "." + s.service();
-            var shape = signatureShape(s);
-            serviceSig.put(key, sha256Hex(shape));
-        }
-
-        Map<String, List<String>> attrEnums = new LinkedHashMap<>();
-        for (Entity e : ManifestCanonicalizer.canonicalize(manifest).entities()) {
-            if (e.attributes() == null) continue;
-            for (var entry : e.attributes().entrySet()) {
-                var attr = entry.getKey();
-                var desc = entry.getValue();
-
-                if (desc.enumValues() == null || desc.enumValues().isEmpty()) continue;
-                var key = e.domain() + "." + attr;
-                var list = attrEnums.computeIfAbsent(key, k -> new ArrayList<>());
-                list.addAll(desc.enumValues());
-            }
-        }
-
-        for (var it : attrEnums.entrySet()) {
-            List<String> uniqSorted = it.getValue().stream()
-                    .distinct()
-                    .sorted()
-                    .toList();
-            it.setValue(uniqSorted);
-        }
-
-        return new LockFile(
-                1,
-                manifestHash,
-                DateTimeFormatter.ISO_INSTANT.format(nowUtc),
-                entityMap,
-                serviceSig,
-                attrEnums.isEmpty() ? null : attrEnums
-        );
+      entityMap.put(e.entity_id(), stable);
     }
 
-    private static String serialise(Manifest m) {
-        try {
-            return ManifestJson.toPrettyString(ManifestCanonicalizer.canonicalize(m));
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to serialise manifest", e);
-        }
+    Map<String, String> serviceSig = new LinkedHashMap<>();
+    for (Service s : ManifestCanonicalizer.canonicalize(manifest).services()) {
+      var key = s.domain() + "." + s.service();
+      var shape = signatureShape(s);
+      serviceSig.put(key, sha256Hex(shape));
     }
 
-    private static String signatureShape(Service s) {
-        var fields = new ArrayList<String>();
+    Map<String, List<String>> attrEnums = new LinkedHashMap<>();
+    for (Entity e : ManifestCanonicalizer.canonicalize(manifest).entities()) {
+      if (e.attributes() == null) continue;
+      for (var entry : e.attributes().entrySet()) {
+        var attr = entry.getKey();
+        var desc = entry.getValue();
 
-        if(s.fields() != null) {
-            s.fields().entrySet().stream()
-                    .sorted(Map.Entry.comparingByKey())
-                    .forEach(e -> {
-                        var serviceField = e.getValue();
-                        var sb = new StringBuilder();
-
-                        sb.append(e.getKey())
-                                .append(":")
-                                .append(nullToEmpty(serviceField.type()));
-
-                        if(Boolean.TRUE.equals(serviceField.required())) sb.append(":req");
-                        if(serviceField.unit() != null && !serviceField.unit().isBlank())
-                            sb.append(":").append(serviceField.unit());
-
-                        fields.add(sb.toString());
-                    });
-        }
-
-        return s.domain() + "." + s.service() + "|" + String.join("|", fields);
+        if (desc.enumValues() == null || desc.enumValues().isEmpty()) continue;
+        var key = e.domain() + "." + attr;
+        var list = attrEnums.computeIfAbsent(key, k -> new ArrayList<>());
+        list.addAll(desc.enumValues());
+      }
     }
 
-    private static String sha256Hex(String s) {
-        try {
-            var md = MessageDigest.getInstance("SHA-256");
-            var d = md.digest(s.getBytes(StandardCharsets.UTF_8));
-            return Hex.of(d);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    for (var it : attrEnums.entrySet()) {
+      List<String> uniqSorted = it.getValue().stream().distinct().sorted().toList();
+      it.setValue(uniqSorted);
     }
 
-    private static final class Hex {
-        private static final char[] HEX = "0123456789abcdef".toCharArray();
+    return new LockFile(
+        1,
+        manifestHash,
+        DateTimeFormatter.ISO_INSTANT.format(nowUtc),
+        entityMap,
+        serviceSig,
+        attrEnums.isEmpty() ? null : attrEnums);
+  }
 
-        static String of(byte[] b) {
-            var out = new char[b.length * 2];
-            for (int i = 0, j = 0; i < b.length; i++) {
-                var v = b[i] & 0xFF;
-                out[j++] = HEX[v >> 4];
-                out[j++] = HEX[v & 0x0f];
-            }
-            return new String(out);
-        }
+  private static String serialise(Manifest m) {
+    try {
+      return ManifestJson.toPrettyString(ManifestCanonicalizer.canonicalize(m));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to serialise manifest", e);
+    }
+  }
+
+  private static String signatureShape(Service s) {
+    var fields = new ArrayList<String>();
+
+    if (s.fields() != null) {
+      s.fields().entrySet().stream()
+          .sorted(Map.Entry.comparingByKey())
+          .forEach(
+              e -> {
+                var serviceField = e.getValue();
+                var sb = new StringBuilder();
+
+                sb.append(e.getKey()).append(":").append(nullToEmpty(serviceField.type()));
+
+                if (Boolean.TRUE.equals(serviceField.required())) sb.append(":req");
+                if (serviceField.unit() != null && !serviceField.unit().isBlank())
+                  sb.append(":").append(serviceField.unit());
+
+                fields.add(sb.toString());
+              });
     }
 
-    private static String nullToEmpty(String s) {
-        return s == null ? "" : s;
+    return s.domain() + "." + s.service() + "|" + String.join("|", fields);
+  }
+
+  private static String sha256Hex(String s) {
+    try {
+      var md = MessageDigest.getInstance("SHA-256");
+      var d = md.digest(s.getBytes(StandardCharsets.UTF_8));
+      return Hex.of(d);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+  }
+
+  private static final class Hex {
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    static String of(byte[] b) {
+      var out = new char[b.length * 2];
+      for (int i = 0, j = 0; i < b.length; i++) {
+        var v = b[i] & 0xFF;
+        out[j++] = HEX[v >> 4];
+        out[j++] = HEX[v & 0x0f];
+      }
+      return new String(out);
+    }
+  }
+
+  private static String nullToEmpty(String s) {
+    return s == null ? "" : s;
+  }
 }

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockFile.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockFile.java
@@ -1,0 +1,25 @@
+package io.pulseautomate.map.manifest.lock;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+import java.util.List;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+        "schema",
+        "manifest_hash",
+        "generated_at",
+        "entity_map",
+        "service_sig",
+        "attr_enums"})
+public record LockFile(
+        int schema,
+        String manifest_hash,
+        String generated_at,
+        Map<String, String> entity_map,
+        Map<String,String> service_sig,
+        Map<String, List<String>> attr_enums
+) {
+}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockFile.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockFile.java
@@ -2,24 +2,22 @@ package io.pulseautomate.map.manifest.lock;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
 import java.util.List;
 import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-        "schema",
-        "manifest_hash",
-        "generated_at",
-        "entity_map",
-        "service_sig",
-        "attr_enums"})
+  "schema",
+  "manifest_hash",
+  "generated_at",
+  "entity_map",
+  "service_sig",
+  "attr_enums"
+})
 public record LockFile(
-        int schema,
-        String manifest_hash,
-        String generated_at,
-        Map<String, String> entity_map,
-        Map<String,String> service_sig,
-        Map<String, List<String>> attr_enums
-) {
-}
+    int schema,
+    String manifest_hash,
+    String generated_at,
+    Map<String, String> entity_map,
+    Map<String, String> service_sig,
+    Map<String, List<String>> attr_enums) {}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockJson.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockJson.java
@@ -4,28 +4,28 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
 public final class LockJson {
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+          .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-    private LockJson() {}
+  private LockJson() {}
 
-    public static String toPrettyString(LockFile lf) throws IOException {
-        return MAPPER.writer(new DefaultPrettyPrinter()).writeValueAsString(lf);
-    }
+  public static String toPrettyString(LockFile lf) throws IOException {
+    return MAPPER.writer(new DefaultPrettyPrinter()).writeValueAsString(lf);
+  }
 
-    public static void writePretty(Path path, LockFile lf) throws IOException {
-        Files.createDirectories(path.getParent());
-        MAPPER.writer(new DefaultPrettyPrinter()).writeValue(path.toFile(), lf);
-    }
+  public static void writePretty(Path path, LockFile lf) throws IOException {
+    Files.createDirectories(path.getParent());
+    MAPPER.writer(new DefaultPrettyPrinter()).writeValue(path.toFile(), lf);
+  }
 
-    public static LockFile read(Path path) throws IOException {
-        return MAPPER.readValue(path.toFile(), LockFile.class);
-    }
+  public static LockFile read(Path path) throws IOException {
+    return MAPPER.readValue(path.toFile(), LockFile.class);
+  }
 }

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockJson.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockJson.java
@@ -1,0 +1,31 @@
+package io.pulseautomate.map.manifest.lock;
+
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class LockJson {
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private LockJson() {}
+
+    public static String toPrettyString(LockFile lf) throws IOException {
+        return MAPPER.writer(new DefaultPrettyPrinter()).writeValueAsString(lf);
+    }
+
+    public static void writePretty(Path path, LockFile lf) throws IOException {
+        Files.createDirectories(path.getParent());
+        MAPPER.writer(new DefaultPrettyPrinter()).writeValue(path.toFile(), lf);
+    }
+
+    public static LockFile read(Path path) throws IOException {
+        return MAPPER.readValue(path.toFile(), LockFile.class);
+    }
+}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/util/Constants.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/util/Constants.java
@@ -1,28 +1,25 @@
 package io.pulseautomate.map.manifest.util;
 
 public final class Constants {
-    private Constants() {}
+  private Constants() {}
 
-    // === Stable IDs ===
-    public static final String STABLE_PREFIX = "stable:";
-    public static final int STABLE_ID_HEX_LENGTH = 12;
+  // === Stable IDs ===
+  public static final String STABLE_PREFIX = "stable:";
+  public static final int STABLE_ID_HEX_LENGTH = 12;
 
-    // === Service signature formatting ===
-    /**
-     * Used between name and field list
-     */
-    public static final char SIG_MAIN_SEP = '|';
-    /**
-     * Used between fields
-     */
-    public static final char SIG_FIELD_SEP = ',';
-    /**
-     * Used between parts of a field
-     */
-    public static final char SIG_PART_SEP = ':';
-    public static final String SIG_REQ_FLAG = ":req";
+  // === Service signature formatting ===
+  /** Used between name and field list */
+  public static final char SIG_MAIN_SEP = '|';
 
-    // === Schema versions ===
-    public static final int MANIFEST_SCHEMA_V1 = 1;
-    public static final int LOCK_SCHEMA_V1 = 1;
+  /** Used between fields */
+  public static final char SIG_FIELD_SEP = ',';
+
+  /** Used between parts of a field */
+  public static final char SIG_PART_SEP = ':';
+
+  public static final String SIG_REQ_FLAG = ":req";
+
+  // === Schema versions ===
+  public static final int MANIFEST_SCHEMA_V1 = 1;
+  public static final int LOCK_SCHEMA_V1 = 1;
 }

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/util/Constants.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/util/Constants.java
@@ -1,0 +1,28 @@
+package io.pulseautomate.map.manifest.util;
+
+public final class Constants {
+    private Constants() {}
+
+    // === Stable IDs ===
+    public static final String STABLE_PREFIX = "stable:";
+    public static final int STABLE_ID_HEX_LENGTH = 12;
+
+    // === Service signature formatting ===
+    /**
+     * Used between name and field list
+     */
+    public static final char SIG_MAIN_SEP = '|';
+    /**
+     * Used between fields
+     */
+    public static final char SIG_FIELD_SEP = ',';
+    /**
+     * Used between parts of a field
+     */
+    public static final char SIG_PART_SEP = ':';
+    public static final String SIG_REQ_FLAG = ":req";
+
+    // === Schema versions ===
+    public static final int MANIFEST_SCHEMA_V1 = 1;
+    public static final int LOCK_SCHEMA_V1 = 1;
+}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/util/HashAlgo.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/util/HashAlgo.java
@@ -3,13 +3,19 @@ package io.pulseautomate.map.manifest.util;
 import java.security.MessageDigest;
 
 public enum HashAlgo {
-    SHA256("SHA-256");
+  SHA256("SHA-256");
 
-    public final String jca;
-    HashAlgo(String jca) { this.jca = jca; }
+  public final String jca;
 
-    public MessageDigest newDigest() {
-        try { return MessageDigest.getInstance(jca); }
-        catch (Exception e) { throw new RuntimeException("Missing JCA digest: " + jca, e); }
+  HashAlgo(String jca) {
+    this.jca = jca;
+  }
+
+  public MessageDigest newDigest() {
+    try {
+      return MessageDigest.getInstance(jca);
+    } catch (Exception e) {
+      throw new RuntimeException("Missing JCA digest: " + jca, e);
     }
+  }
 }

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/util/HashAlgo.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/util/HashAlgo.java
@@ -1,0 +1,15 @@
+package io.pulseautomate.map.manifest.util;
+
+import java.security.MessageDigest;
+
+public enum HashAlgo {
+    SHA256("SHA-256");
+
+    public final String jca;
+    HashAlgo(String jca) { this.jca = jca; }
+
+    public MessageDigest newDigest() {
+        try { return MessageDigest.getInstance(jca); }
+        catch (Exception e) { throw new RuntimeException("Missing JCA digest: " + jca, e); }
+    }
+}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/util/Hashing.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/util/Hashing.java
@@ -4,10 +4,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.HexFormat;
 
 public final class Hashing {
-    private Hashing() {}
+  private Hashing() {}
 
-    public static String sha256Hex(String s) {
-        var md = HashAlgo.SHA256.newDigest();
-        return HexFormat.of().formatHex(md.digest(s.getBytes(StandardCharsets.UTF_8)));
-    }
+  public static String sha256Hex(String s) {
+    var md = HashAlgo.SHA256.newDigest();
+    return HexFormat.of().formatHex(md.digest(s.getBytes(StandardCharsets.UTF_8)));
+  }
 }

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/util/Hashing.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/util/Hashing.java
@@ -1,0 +1,13 @@
+package io.pulseautomate.map.manifest.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+public final class Hashing {
+    private Hashing() {}
+
+    public static String sha256Hex(String s) {
+        var md = HashAlgo.SHA256.newDigest();
+        return HexFormat.of().formatHex(md.digest(s.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/manifest/src/test/java/io/pulseautomate/map/manifest/lock/LockBuilderTest.java
+++ b/manifest/src/test/java/io/pulseautomate/map/manifest/lock/LockBuilderTest.java
@@ -12,66 +12,78 @@ import org.junit.jupiter.api.Test;
 
 class LockBuilderTest {
 
-    private Manifest sampleManifest() {
-        var attrs = new LinkedHashMap<String, AttributeDesc>();
-        attrs.put("hvac_mode", new AttributeDesc(FieldKind.ENUM, null, List.of("off","heat","auto"), null, null));
-        attrs.put("preset_mode", new AttributeDesc(FieldKind.ENUM, null, List.of("eco","comfort"), true, null));
-        attrs.put("current_temp_c", new AttributeDesc(FieldKind.NUMBER, "°C", null, null, null));
-        attrs.put("target_temp_c", new AttributeDesc(FieldKind.NUMBER, "°C", null, null, new CapabilityRange(5.0, 30.0, 0.5)));
+  private Manifest sampleManifest() {
+    var attrs = new LinkedHashMap<String, AttributeDesc>();
+    attrs.put(
+        "hvac_mode",
+        new AttributeDesc(FieldKind.ENUM, null, List.of("off", "heat", "auto"), null, null));
+    attrs.put(
+        "preset_mode",
+        new AttributeDesc(FieldKind.ENUM, null, List.of("eco", "comfort"), true, null));
+    attrs.put("current_temp_c", new AttributeDesc(FieldKind.NUMBER, "°C", null, null, null));
+    attrs.put(
+        "target_temp_c",
+        new AttributeDesc(FieldKind.NUMBER, "°C", null, null, new CapabilityRange(5.0, 30.0, 0.5)));
 
-        var entity = new Entity("stable:aa12…", "climate.living_room_trv", "climate", "heater", null, attrs);
+    var entity =
+        new Entity("stable:aa12…", "climate.living_room_trv", "climate", "heater", null, attrs);
 
-        var fields = new LinkedHashMap<String, ServiceField>();
-        fields.put("temperature", new ServiceField("number", "°C", true));
-        var service = new Service("climate", "set_temperature", fields);
+    var fields = new LinkedHashMap<String, ServiceField>();
+    fields.put("temperature", new ServiceField("number", "°C", true));
+    var service = new Service("climate", "set_temperature", fields);
 
-        return new Manifest(1, "2025.6", List.of(entity), List.of(service));
-    }
+    return new Manifest(1, "2025.6", List.of(entity), List.of(service));
+  }
 
-    @Test
-    void builds_lock_with_hashes_and_maps() throws Exception {
-        var manifest = sampleManifest();
-        var now = Instant.parse("2025-08-14T19:00:00Z");
-        var lock = LockBuilder.build(manifest, null, now);
+  @Test
+  void builds_lock_with_hashes_and_maps() throws Exception {
+    var manifest = sampleManifest();
+    var now = Instant.parse("2025-08-14T19:00:00Z");
+    var lock = LockBuilder.build(manifest, null, now);
 
-        // manifest hash should be sha256 of canonicalized pretty json
-        var canonJson = ManifestJson.toPrettyString(ManifestCanonicalizer.canonicalize(manifest));
-        assertThat(lock.manifest_hash()).hasSize(64);
-        assertThat(lock.generated_at()).isEqualTo("2025-08-14T19:00:00Z");
+    // manifest hash should be sha256 of canonicalized pretty json
+    var canonJson = ManifestJson.toPrettyString(ManifestCanonicalizer.canonicalize(manifest));
+    assertThat(lock.manifest_hash()).hasSize(64);
+    assertThat(lock.generated_at()).isEqualTo("2025-08-14T19:00:00Z");
 
-        // entity map should contain our entity_id -> stable_id
-        assertThat(lock.entity_map()).containsEntry("climate.living_room_trv", "stable:aa12…");
+    // entity map should contain our entity_id -> stable_id
+    assertThat(lock.entity_map()).containsEntry("climate.living_room_trv", "stable:aa12…");
 
-        // service signature should exist and be deterministic
-        var sig = lock.service_sig().get("climate.set_temperature");
-        assertThat(sig).isNotNull().hasSize(64);
+    // service signature should exist and be deterministic
+    var sig = lock.service_sig().get("climate.set_temperature");
+    assertThat(sig).isNotNull().hasSize(64);
 
-        // attr enums should contain climate.hvac_mode & preset_mode; sorted/deduped
-        assertThat(lock.attr_enums()).isNotNull();
-        assertThat(lock.attr_enums().get("climate.hvac_mode")).containsExactly("auto", "heat", "off");
-        assertThat(lock.attr_enums().get("climate.preset_mode")).containsExactly("comfort", "eco");
-    }
+    // attr enums should contain climate.hvac_mode & preset_mode; sorted/deduped
+    assertThat(lock.attr_enums()).isNotNull();
+    assertThat(lock.attr_enums().get("climate.hvac_mode")).containsExactly("auto", "heat", "off");
+    assertThat(lock.attr_enums().get("climate.preset_mode")).containsExactly("comfort", "eco");
+  }
 
-    @Test
-    void reuses_previous_mapping_when_stable_id_missing() {
-        // manifest has NO stable_id (simulating earlier stage before we compute it)
-        var entity = new Entity(null, "light.kitchen", "light", null, null, null);
-        var manifest = new Manifest(1, "2025.6", List.of(entity), List.of());
-        var prev = new LockFile(1, "hash", "2025-01-01T00:00:00Z",
-                java.util.Map.of("light.kitchen", "stable:deadbeefcafe"),
-                java.util.Map.of(), null);
+  @Test
+  void reuses_previous_mapping_when_stable_id_missing() {
+    // manifest has NO stable_id (simulating earlier stage before we compute it)
+    var entity = new Entity(null, "light.kitchen", "light", null, null, null);
+    var manifest = new Manifest(1, "2025.6", List.of(entity), List.of());
+    var prev =
+        new LockFile(
+            1,
+            "hash",
+            "2025-01-01T00:00:00Z",
+            java.util.Map.of("light.kitchen", "stable:deadbeefcafe"),
+            java.util.Map.of(),
+            null);
 
-        var lock = LockBuilder.build(manifest, prev, Instant.parse("2025-08-14T00:00:00Z"));
+    var lock = LockBuilder.build(manifest, prev, Instant.parse("2025-08-14T00:00:00Z"));
 
-        assertThat(lock.entity_map()).containsEntry("light.kitchen", "stable:deadbeefcafe");
-    }
+    assertThat(lock.entity_map()).containsEntry("light.kitchen", "stable:deadbeefcafe");
+  }
 
-    @Test
-    void derives_stable_id_from_entity_id_when_no_previous() {
-        var entity = new Entity(null, "sensor.outdoor_temp", "sensor", null, null, null);
-        var manifest = new Manifest(1, "2025.6", List.of(entity), List.of());
-        var lock = LockBuilder.build(manifest, null, Instant.parse("2025-08-14T00:00:00Z"));
-        // Check shape, not exact hex (algorithm detail)
-        assertThat(lock.entity_map().get("sensor.outdoor_temp")).startsWith("stable:");
-    }
+  @Test
+  void derives_stable_id_from_entity_id_when_no_previous() {
+    var entity = new Entity(null, "sensor.outdoor_temp", "sensor", null, null, null);
+    var manifest = new Manifest(1, "2025.6", List.of(entity), List.of());
+    var lock = LockBuilder.build(manifest, null, Instant.parse("2025-08-14T00:00:00Z"));
+    // Check shape, not exact hex (algorithm detail)
+    assertThat(lock.entity_map().get("sensor.outdoor_temp")).startsWith("stable:");
+  }
 }

--- a/manifest/src/test/java/io/pulseautomate/map/manifest/lock/LockBuilderTest.java
+++ b/manifest/src/test/java/io/pulseautomate/map/manifest/lock/LockBuilderTest.java
@@ -1,0 +1,77 @@
+package io.pulseautomate.map.manifest.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.pulseautomate.map.manifest.model.*;
+import io.pulseautomate.map.manifest.serde.ManifestCanonicalizer;
+import io.pulseautomate.map.manifest.serde.ManifestJson;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LockBuilderTest {
+
+    private Manifest sampleManifest() {
+        var attrs = new LinkedHashMap<String, AttributeDesc>();
+        attrs.put("hvac_mode", new AttributeDesc(FieldKind.ENUM, null, List.of("off","heat","auto"), null, null));
+        attrs.put("preset_mode", new AttributeDesc(FieldKind.ENUM, null, List.of("eco","comfort"), true, null));
+        attrs.put("current_temp_c", new AttributeDesc(FieldKind.NUMBER, "°C", null, null, null));
+        attrs.put("target_temp_c", new AttributeDesc(FieldKind.NUMBER, "°C", null, null, new CapabilityRange(5.0, 30.0, 0.5)));
+
+        var entity = new Entity("stable:aa12…", "climate.living_room_trv", "climate", "heater", null, attrs);
+
+        var fields = new LinkedHashMap<String, ServiceField>();
+        fields.put("temperature", new ServiceField("number", "°C", true));
+        var service = new Service("climate", "set_temperature", fields);
+
+        return new Manifest(1, "2025.6", List.of(entity), List.of(service));
+    }
+
+    @Test
+    void builds_lock_with_hashes_and_maps() throws Exception {
+        var manifest = sampleManifest();
+        var now = Instant.parse("2025-08-14T19:00:00Z");
+        var lock = LockBuilder.build(manifest, null, now);
+
+        // manifest hash should be sha256 of canonicalized pretty json
+        var canonJson = ManifestJson.toPrettyString(ManifestCanonicalizer.canonicalize(manifest));
+        assertThat(lock.manifest_hash()).hasSize(64);
+        assertThat(lock.generated_at()).isEqualTo("2025-08-14T19:00:00Z");
+
+        // entity map should contain our entity_id -> stable_id
+        assertThat(lock.entity_map()).containsEntry("climate.living_room_trv", "stable:aa12…");
+
+        // service signature should exist and be deterministic
+        var sig = lock.service_sig().get("climate.set_temperature");
+        assertThat(sig).isNotNull().hasSize(64);
+
+        // attr enums should contain climate.hvac_mode & preset_mode; sorted/deduped
+        assertThat(lock.attr_enums()).isNotNull();
+        assertThat(lock.attr_enums().get("climate.hvac_mode")).containsExactly("auto", "heat", "off");
+        assertThat(lock.attr_enums().get("climate.preset_mode")).containsExactly("comfort", "eco");
+    }
+
+    @Test
+    void reuses_previous_mapping_when_stable_id_missing() {
+        // manifest has NO stable_id (simulating earlier stage before we compute it)
+        var entity = new Entity(null, "light.kitchen", "light", null, null, null);
+        var manifest = new Manifest(1, "2025.6", List.of(entity), List.of());
+        var prev = new LockFile(1, "hash", "2025-01-01T00:00:00Z",
+                java.util.Map.of("light.kitchen", "stable:deadbeefcafe"),
+                java.util.Map.of(), null);
+
+        var lock = LockBuilder.build(manifest, prev, Instant.parse("2025-08-14T00:00:00Z"));
+
+        assertThat(lock.entity_map()).containsEntry("light.kitchen", "stable:deadbeefcafe");
+    }
+
+    @Test
+    void derives_stable_id_from_entity_id_when_no_previous() {
+        var entity = new Entity(null, "sensor.outdoor_temp", "sensor", null, null, null);
+        var manifest = new Manifest(1, "2025.6", List.of(entity), List.of());
+        var lock = LockBuilder.build(manifest, null, Instant.parse("2025-08-14T00:00:00Z"));
+        // Check shape, not exact hex (algorithm detail)
+        assertThat(lock.entity_map().get("sensor.outdoor_temp")).startsWith("stable:");
+    }
+}


### PR DESCRIPTION
This pull request introduces a new mechanism for generating and managing manifest lock files in the `manifest` package. The main changes include the implementation of stable ID derivation, lock file construction and serialization, hashing utilities, and supporting constants. These changes collectively enable deterministic mapping of entities and services, hashing, and canonicalization for manifest versioning.

**Lock file and stable ID infrastructure:**

* Added `LockFile` record to represent the structure of a manifest lock file, including schema version, manifest hash, generation timestamp, entity-to-stable-ID map, service signatures, and attribute enumerations. (`manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockFile.java`)
* Implemented `LockBuilder` class to construct a `LockFile` from a manifest, previous lock file, and timestamp, including logic for stable ID assignment, service signature hashing, and attribute enum extraction and sorting. (`manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockBuilder.java`)
* Added `StableId` utility class for deriving stable IDs from entity seeds using SHA-256 hashing and a fixed prefix. (`manifest/src/main/java/io/pulseautomate/map/manifest/id/StableId.java`)

**Serialization and hashing utilities:**

* Added `LockJson` utility for pretty-printing, reading, and writing lock files using Jackson, with ordered map entries for determinism. (`manifest/src/main/java/io/pulseautomate/map/manifest/lock/LockJson.java`)
* Introduced `HashAlgo` enum and `Hashing` utility class for SHA-256 hashing and hex formatting. (`manifest/src/main/java/io/pulseautomate/map/manifest/util/HashAlgo.java`, `manifest/src/main/java/io/pulseautomate/map/manifest/util/Hashing.java`) [[1]](diffhunk://#diff-2bfcac94317fc7a8e2ae96927b1a44e619fffdec0f28a93a9f01a591306acd12R1-R21) [[2]](diffhunk://#diff-54c61a1b5072d3cc2a3b76277cba86391bcee19768111b4d970d091d44f5640eR1-R13)

**Constants and test coverage:**

* Defined relevant constants for stable ID formatting, signature formatting, and schema versions in `Constants`. (`manifest/src/main/java/io/pulseautomate/map/manifest/util/Constants.java`)
* Added comprehensive tests for `LockBuilder`, covering manifest hashing, stable ID assignment, service signature determinism, attribute enum sorting/deduplication, and previous mapping reuse. (`manifest/src/test/java/io/pulseautomate/map/manifest/lock/LockBuilderTest.java`)