### PR TITLE
Feat/cli discover

### DIFF
--- a/app-cli/build.gradle.kts
+++ b/app-cli/build.gradle.kts
@@ -25,7 +25,16 @@ graalvmNative {
     binaries {
         named("main") {
             imageName.set("pulse-map")
-            buildArgs.add("-H:+ReportExceptionStackTraces")
+
+            configurationFileDirectories.from(
+                file("${layout.buildDirectory}/native/agent-output/main"),
+                file("${layout.buildDirectory}/native/agent-output/test")
+            )
+
+            buildArgs.addAll(listOf(
+                "--no-fallback",
+                "--install-exit-handlers"
+            ))
         }
     }
 }

--- a/app-cli/build.gradle.kts
+++ b/app-cli/build.gradle.kts
@@ -5,14 +5,20 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":ha-client"))
     implementation(project(":manifest"))
+
     implementation(libs.picocli)
+    implementation(libs.bundles.jackson)
+
     annotationProcessor(libs.picocli.codegen)
+
     testImplementation(libs.junit.jupiter)
+    testImplementation(libs.assertj.core)
 }
 
 application {
-    mainClass.set("io.pulseautomate.map.cli.Main")
+    mainClass.set("io.pulseautomate.map.cli.MapCli")
 }
 
 graalvmNative {

--- a/app-cli/src/main/java/io/pulseautomate/map/cli/MapCli.java
+++ b/app-cli/src/main/java/io/pulseautomate/map/cli/MapCli.java
@@ -1,6 +1,7 @@
 package io.pulseautomate.map.cli;
 
 import io.pulseautomate.map.cli.commands.DiscoverCommand;
+import io.pulseautomate.map.cli.commands.ValidateCommand;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
@@ -9,7 +10,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     version = "pulse-map 0.1",
     description = "Pulse Map CLI",
-    subcommands = {DiscoverCommand.class},
+    subcommands = {DiscoverCommand.class, ValidateCommand.class},
     synopsisSubcommandLabel = "COMMAND")
 public final class MapCli implements Callable<Integer> {
   public static void main(String[] args) {

--- a/app-cli/src/main/java/io/pulseautomate/map/cli/MapCli.java
+++ b/app-cli/src/main/java/io/pulseautomate/map/cli/MapCli.java
@@ -1,5 +1,7 @@
 package io.pulseautomate.map.cli;
 
+import io.pulseautomate.map.cli.commands.DiscoverCommand;
+import java.util.concurrent.Callable;
 import picocli.CommandLine;
 
 @CommandLine.Command(
@@ -7,15 +9,17 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     version = "pulse-map 0.1",
     description = "Pulse Map CLI",
-    subcommands = {})
-public final class MapCli implements Runnable {
+    subcommands = {DiscoverCommand.class},
+    synopsisSubcommandLabel = "COMMAND")
+public final class MapCli implements Callable<Integer> {
   public static void main(String[] args) {
     var code = new CommandLine(new MapCli()).execute(args);
     System.exit(code);
   }
 
   @Override
-  public void run() {
+  public Integer call() throws Exception {
     new CommandLine(this).usage(System.out);
+    return CommandLine.ExitCode.OK;
   }
 }

--- a/app-cli/src/main/java/io/pulseautomate/map/cli/MapCli.java
+++ b/app-cli/src/main/java/io/pulseautomate/map/cli/MapCli.java
@@ -1,6 +1,7 @@
 package io.pulseautomate.map.cli;
 
 import io.pulseautomate.map.cli.commands.DiscoverCommand;
+import io.pulseautomate.map.cli.commands.StatsCommand;
 import io.pulseautomate.map.cli.commands.ValidateCommand;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
@@ -10,7 +11,7 @@ import picocli.CommandLine;
     mixinStandardHelpOptions = true,
     version = "pulse-map 0.1",
     description = "Pulse Map CLI",
-    subcommands = {DiscoverCommand.class, ValidateCommand.class},
+    subcommands = {DiscoverCommand.class, ValidateCommand.class, StatsCommand.class},
     synopsisSubcommandLabel = "COMMAND")
 public final class MapCli implements Callable<Integer> {
   public static void main(String[] args) {

--- a/app-cli/src/main/java/io/pulseautomate/map/cli/MapCli.java
+++ b/app-cli/src/main/java/io/pulseautomate/map/cli/MapCli.java
@@ -1,0 +1,21 @@
+package io.pulseautomate.map.cli;
+
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "pulse-map",
+    mixinStandardHelpOptions = true,
+    version = "pulse-map 0.1",
+    description = "Pulse Map CLI",
+    subcommands = {})
+public final class MapCli implements Runnable {
+  public static void main(String[] args) {
+    var code = new CommandLine(new MapCli()).execute(args);
+    System.exit(code);
+  }
+
+  @Override
+  public void run() {
+    new CommandLine(this).usage(System.out);
+  }
+}

--- a/app-cli/src/main/java/io/pulseautomate/map/cli/commands/DiscoverCommand.java
+++ b/app-cli/src/main/java/io/pulseautomate/map/cli/commands/DiscoverCommand.java
@@ -1,0 +1,76 @@
+package io.pulseautomate.map.cli.commands;
+
+import io.pulseautomate.map.cli.run.DiscoverRunner;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "discover",
+    mixinStandardHelpOptions = true,
+    description = "Discover from Home Assistant and write manifest.json and map.lock.json")
+public final class DiscoverCommand implements Callable<Integer> {
+  @CommandLine.Option(
+      names = {"--out"},
+      paramLabel = "<dir>",
+      description = "Output directory for manifest.json and map.lock.json",
+      required = true)
+  Path outDir;
+
+  @CommandLine.Option(
+      names = {"--ha-url"},
+      paramLabel = "<url>",
+      description = "Home Assistant base URL (fallback: $HA_URL)")
+  URI haUrl;
+
+  @CommandLine.Option(
+      names = {"--ha-token"},
+      paramLabel = "<token>",
+      description = "Home Assistant long-lived access token (fallback: $HA_TOKEN)")
+  String haToken;
+
+  @CommandLine.Option(
+      names = {"--ha-version"},
+      paramLabel = "<ver>",
+      description = "Home Assistant version label to embed in manifest (fallback: $HA_VERSION)")
+  String haVersion;
+
+  static DiscoverRunner.Factory factory = DiscoverRunner::forHomeAssistant;
+
+  @Override
+  public Integer call() throws Exception {
+    var url = haUrl != null ? haUrl : envUri("HA_URL");
+    var token = firstNonBlank(haToken, getEnv("HA_TOKEN"));
+    var version = firstNonBlank(haVersion, getEnv("HA_VERSION"));
+
+    DiscoverRunner runner;
+    if (url == null || isBlank(token)) runner = DiscoverRunner.forSnapshotOnly(version);
+    else runner = factory.create(url, token, version);
+
+    var res = runner.run(outDir);
+
+    System.out.printf("Wrote:%n %s%n %s%n", res.manifestPath(), res.lockPath());
+    System.out.printf("Entities: %d, Services: %d%n", res.entities(), res.services());
+
+    return 0;
+  }
+
+  private static String getEnv(String k) {
+    var v = System.getenv(k);
+    return isBlank(v) ? null : v;
+  }
+
+  private static URI envUri(String k) {
+    var v = System.getenv(k);
+    return isBlank(v) ? null : URI.create(v);
+  }
+
+  private static String firstNonBlank(String a, String b) {
+    return isBlank(a) ? b : a;
+  }
+
+  private static boolean isBlank(String s) {
+    return s == null || s.isBlank();
+  }
+}

--- a/app-cli/src/main/java/io/pulseautomate/map/cli/commands/StatsCommand.java
+++ b/app-cli/src/main/java/io/pulseautomate/map/cli/commands/StatsCommand.java
@@ -1,0 +1,65 @@
+package io.pulseautomate.map.cli.commands;
+
+import io.pulseautomate.map.manifest.serde.ManifestJson;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "stats",
+    mixinStandardHelpOptions = true,
+    description =
+        "Print quick stats for a manifest.json (per-domain counts and attribute coverage).")
+public final class StatsCommand implements Callable<Integer> {
+  @CommandLine.Option(
+      names = {"--manifest"},
+      description = "Path to manifest.json file.",
+      paramLabel = "<file>",
+      defaultValue = "manifest.json")
+  Path manifestPath;
+
+  @CommandLine.Option(
+      names = {"--top"},
+      description = "Show top N domains",
+      paramLabel = "<n>",
+      defaultValue = "10")
+  int topN;
+
+  @Override
+  public Integer call() throws Exception {
+    var manifest = ManifestJson.read(manifestPath);
+    var domainCounts = new HashMap<String, Integer>();
+    var attrCounts = new HashMap<String, Integer>();
+
+    if (manifest.entities() != null) {
+      for (var e : manifest.entities()) {
+        domainCounts.merge(e.domain(), 1, Integer::sum);
+        if (e.attributes() != null) {
+          for (var a : e.attributes().keySet()) {
+            attrCounts.merge(e.domain() + "." + a, 1, Integer::sum);
+          }
+        }
+      }
+    }
+
+    var totalEntities = manifest.entities() == null ? 0 : manifest.entities().size();
+    var totalServices = manifest.services() == null ? 0 : manifest.services().size();
+
+    System.out.println("Entities: " + totalEntities + " Services: " + totalServices);
+
+    System.out.println("Top domains:");
+    domainCounts.entrySet().stream()
+        .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+        .limit(topN)
+        .forEach(e -> System.out.printf(" %-16s %5d%n", e.getKey(), e.getValue()));
+
+    System.out.println("Top attributes (domain.attr):");
+    attrCounts.entrySet().stream()
+        .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+        .limit(topN)
+        .forEach(e -> System.out.printf(" %-24s %5d%n", e.getKey(), e.getValue()));
+
+    return 0;
+  }
+}

--- a/app-cli/src/main/java/io/pulseautomate/map/cli/commands/ValidateCommand.java
+++ b/app-cli/src/main/java/io/pulseautomate/map/cli/commands/ValidateCommand.java
@@ -1,0 +1,82 @@
+package io.pulseautomate.map.cli.commands;
+
+import io.pulseautomate.map.manifest.lock.LockBuilder;
+import io.pulseautomate.map.manifest.lock.LockJson;
+import io.pulseautomate.map.manifest.serde.ManifestCanonicalizer;
+import io.pulseautomate.map.manifest.serde.ManifestJson;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "validate",
+    mixinStandardHelpOptions = true,
+    description = "Validate manifest.json against map.lock.json (hash and coverage).")
+public final class ValidateCommand implements Callable<Integer> {
+  @CommandLine.Option(
+      names = {"--dir"},
+      description = "Directory containing the manifest.json and map.lock.json files.",
+      paramLabel = "<dir>",
+      defaultValue = ".")
+  Path dir;
+
+  @CommandLine.Option(
+      names = {"--strict"},
+      description = "Exit with non-zero status if any validation issue is found")
+  boolean strict;
+
+  @Override
+  public Integer call() throws Exception {
+    var manifestPath = dir.resolve("manifest.json");
+    var lockPath = dir.resolve("map.lock.json");
+
+    if (!Files.exists(manifestPath)) {
+      System.err.println("manifest.json not found: " + manifestPath.toAbsolutePath());
+      return 2;
+    }
+    if (!Files.exists(lockPath)) {
+      System.err.println("map.lock.json not found: " + lockPath.toAbsolutePath());
+      return 2;
+    }
+
+    var manifest = ManifestJson.read(manifestPath);
+    var canon = ManifestCanonicalizer.canonicalize(manifest);
+    var lock = LockJson.read(lockPath);
+
+    var recomputed = LockBuilder.build(canon, null, Instant.EPOCH).manifest_hash();
+    var hashOk = recomputed.equals(lock.manifest_hash());
+
+    var missingStable = 0;
+    if (canon.entities() != null) {
+      for (var e : canon.entities()) {
+        var stable = lock.entity_map() != null ? lock.entity_map().get(e.entity_id()) : null;
+        if (stable == null || stable.isBlank()) {
+          System.err.println("[MISSING] stable_id for " + e.entity_id());
+          missingStable++;
+        }
+      }
+    }
+
+    var missingServiceSig = 0;
+    if (canon.services() != null) {
+      for (var s : canon.services()) {
+        var key = s.domain() + "." + s.service();
+        var sig = lock.service_sig() != null ? lock.service_sig().get(key) : null;
+        if (sig == null || sig.isBlank()) {
+          System.err.println("[MISSING] service signature for " + key);
+          missingServiceSig++;
+        }
+      }
+    }
+
+    System.out.println("Hash match: " + (hashOk ? "OK" : "FAIL"));
+    System.out.println("Entities without stable_id: " + missingStable);
+    System.out.println("Services without signature: " + missingServiceSig);
+
+    var ok = hashOk && missingStable == 0 && missingServiceSig == 0;
+    if (!ok && strict) return 1;
+    return 0;
+  }
+}

--- a/app-cli/src/main/java/io/pulseautomate/map/cli/run/DiscoverRunner.java
+++ b/app-cli/src/main/java/io/pulseautomate/map/cli/run/DiscoverRunner.java
@@ -1,0 +1,119 @@
+package io.pulseautomate.map.cli.run;
+
+import io.pulseautomate.map.ha.client.HAHttpClient;
+import io.pulseautomate.map.ha.config.HAConfig;
+import io.pulseautomate.map.ha.model.HASnapshot;
+import io.pulseautomate.map.manifest.builder.ManifestBuilder;
+import io.pulseautomate.map.manifest.lock.LockBuilder;
+import io.pulseautomate.map.manifest.lock.LockFile;
+import io.pulseautomate.map.manifest.lock.LockJson;
+import io.pulseautomate.map.manifest.serde.ManifestCanonicalizer;
+import io.pulseautomate.map.manifest.serde.ManifestJson;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+public final class DiscoverRunner {
+
+  public interface Factory {
+    DiscoverRunner create(URI haUrl, String token, String haVersionOpt);
+  }
+
+  public static DiscoverRunner forHomeAssistant(URI haUrl, String token, String haVersionOpt) {
+    Objects.requireNonNull(haUrl);
+    Objects.requireNonNull(token);
+
+    SnapshotProvider provider = new HAProvider(haUrl, token, haVersionOpt);
+    return new DiscoverRunner(provider, new ManifestBuilder());
+  }
+
+  public static DiscoverRunner forSnapshotOnly(String haVersionOpt) {
+    SnapshotProvider provider =
+        new SnapshotProvider() {
+          @Override
+          public HASnapshot fetch() throws Exception {
+            return new HASnapshot(List.of(), List.of());
+          }
+
+          @Override
+          public String haVersion() throws Exception {
+            return (haVersionOpt != null && !haVersionOpt.isBlank()) ? haVersionOpt : "unknown";
+          }
+        };
+
+    return new DiscoverRunner(provider, new ManifestBuilder());
+  }
+
+  public record Result(Path manifestPath, Path lockPath, int entities, int services) {}
+
+  public interface SnapshotProvider {
+    HASnapshot fetch() throws Exception;
+
+    String haVersion() throws Exception;
+  }
+
+  private final SnapshotProvider provider;
+  private final ManifestBuilder builder;
+
+  public DiscoverRunner(SnapshotProvider provider, ManifestBuilder builder) {
+    this.provider = provider;
+    this.builder = builder;
+  }
+
+  public Result run(Path outDir) throws Exception {
+    Files.createDirectories(outDir);
+
+    var snap = provider.fetch();
+    var version = provider.haVersion();
+
+    var manifest = builder.build(version, snap);
+    var canon = ManifestCanonicalizer.canonicalize(manifest);
+
+    var manifestPath = outDir.resolve("manifest.json");
+    ManifestJson.writePretty(manifestPath, canon);
+
+    var lockPath = outDir.resolve("map.lock.json");
+    LockFile prev = null;
+    if (Files.exists(lockPath))
+      try {
+        prev = LockJson.read(lockPath);
+      } catch (IOException ignore) {
+      }
+
+    var lock = LockBuilder.build(canon, prev, Instant.now());
+    LockJson.writePretty(lockPath, lock);
+
+    var entities = canon.entities() == null ? 0 : canon.entities().size();
+    var services = canon.services() == null ? 0 : canon.services().size();
+    return new Result(manifestPath, lockPath, entities, services);
+  }
+
+  private static final class HAProvider implements SnapshotProvider {
+    private final URI url;
+    private final String token;
+    private final String haVersionOpt;
+
+    public HAProvider(URI url, String token, String haVersionOpt) {
+      this.url = url;
+      this.token = token;
+      this.haVersionOpt = haVersionOpt;
+    }
+
+    @Override
+    public HASnapshot fetch() throws Exception {
+      var client = new HAHttpClient(HAConfig.of(url, token));
+      var states = client.fetchStates();
+      var services = client.fetchServices();
+      return new HASnapshot(states, services);
+    }
+
+    @Override
+    public String haVersion() throws Exception {
+      return (haVersionOpt != null && !haVersionOpt.isBlank()) ? haVersionOpt : "unknown";
+    }
+  }
+}

--- a/app-cli/src/test/java/io/pulseautomate/map/cli/run/DiscoverRunnerTest.java
+++ b/app-cli/src/test/java/io/pulseautomate/map/cli/run/DiscoverRunnerTest.java
@@ -1,0 +1,72 @@
+package io.pulseautomate.map.cli.run;
+
+import static io.pulseautomate.map.manifest.util.Names.Attr.HVAC_MODE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.pulseautomate.map.ha.model.HAService;
+import io.pulseautomate.map.ha.model.HAServiceField;
+import io.pulseautomate.map.ha.model.HASnapshot;
+import io.pulseautomate.map.ha.model.HAState;
+import io.pulseautomate.map.manifest.lock.LockFile;
+import io.pulseautomate.map.manifest.lock.LockJson;
+import io.pulseautomate.map.manifest.model.Manifest;
+import io.pulseautomate.map.manifest.serde.ManifestJson;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+final class DiscoverRunnerTest {
+
+  @TempDir Path tmp;
+
+  @Test
+  void writes_manifest_and_lock_and_reuses_lock_on_second_run() throws Exception {
+    var a = new LinkedHashMap<String, Object>();
+    a.put("hvac_modes", List.of("off", "heat", "auto"));
+    a.put("min_temp", 5.0);
+    a.put("max_temp", 30.0);
+    a.put("target_temp_step", 0.5);
+    a.put("temperature_unit", "°C");
+    var state = new HAState("climate.living_room_trv", "heat", a, null, null);
+
+    var fields = Map.of("temperature", new HAServiceField(true, null, null, "Set temp"));
+    var svc = new HAService("climate", "set_temperature", fields);
+
+    var provider =
+        new DiscoverRunner.SnapshotProvider() {
+          @Override
+          public HASnapshot fetch() {
+            return new HASnapshot(List.of(state), List.of(svc));
+          }
+
+          @Override
+          public String haVersion() {
+            return "2025.6";
+          }
+        };
+
+    var runner =
+        new DiscoverRunner(provider, new io.pulseautomate.map.manifest.builder.ManifestBuilder());
+
+    var r1 = runner.run(tmp);
+    assertThat(Files.exists(r1.manifestPath())).isTrue();
+    assertThat(Files.exists(r1.lockPath())).isTrue();
+
+    Manifest m1 = ManifestJson.read(r1.manifestPath());
+    assertThat(m1.entities()).hasSize(1);
+    assertThat(m1.entities().getFirst().attributes()).containsKey(HVAC_MODE);
+
+    LockFile lf1 = LockJson.read(r1.lockPath());
+    String stable1 = lf1.entity_map().get("climate.living_room_trv");
+    assertThat(stable1).startsWith("stable:");
+
+    var r2 = runner.run(tmp);
+    LockFile lf2 = LockJson.read(r2.lockPath());
+    String stable2 = lf2.entity_map().get("climate.living_room_trv");
+    assertThat(stable2).isEqualTo(stable1);
+  }
+}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/builder/ManifestBuilder.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/builder/ManifestBuilder.java
@@ -53,7 +53,8 @@ public final class ManifestBuilder {
       fields = null;
     }
 
-    return new Service(hs.domain(), hs.service(), fields);
+    var typedFields = ServiceTyping.apply(hs, fields);
+    return new Service(hs.domain(), hs.service(), typedFields);
   }
 
   private static String domainOf(String entityId) {

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/builder/ServiceTyping.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/builder/ServiceTyping.java
@@ -1,0 +1,113 @@
+package io.pulseautomate.map.manifest.builder;
+
+import static io.pulseautomate.map.manifest.util.Constants.*;
+import static io.pulseautomate.map.manifest.util.Names.Domain.*;
+import static io.pulseautomate.map.manifest.util.Names.SvcField.*;
+import static io.pulseautomate.map.manifest.util.Names.SvcField.KELVIN;
+
+import io.pulseautomate.map.ha.model.HAService;
+import io.pulseautomate.map.manifest.model.ServiceField;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public final class ServiceTyping {
+  private ServiceTyping() {}
+
+  static Map<String, ServiceField> apply(HAService svc, Map<String, ServiceField> in) {
+    if (in == null || in.isEmpty()) return in;
+    var d = svc.domain();
+    var s = svc.service();
+
+    var out = new LinkedHashMap<String, ServiceField>(in.size());
+    in.forEach((name, f) -> out.put(name, typed(d, s, name, f)));
+    return out;
+  }
+
+  private static ServiceField typed(String domain, String service, String name, ServiceField f) {
+    var type = f.type();
+    var unit = f.unit();
+
+    // --- Climate ---
+    if (CLIMATE.equals(domain)) {
+      if ("set_temperature".equals(service) && TEMPERATURE.equals(name)) {
+        type = nullable(type, "number");
+        unit = nullable(unit, UNIT_CELSIUS_WITH_SYMBOL);
+      } else if ("set_hvac_mode".equals(service) && HVAC_MODE.equals(name)) {
+        type = nullable(type, "enum");
+      } else if ("set_preset_mode".equals(service) && PRESET_MODE.equals(name)) {
+        type = nullable(type, "enum");
+      }
+    }
+
+    // --- Light ---
+    else if (LIGHT.equals(domain) && "turn_on".equals(service)) {
+      if (BRIGHTNESS_PCT.equals(name)) {
+        type = nullable(type, "percent");
+        unit = nullable(unit, UNIT_PERCENT);
+      } else if (COLOR_TEMP.equals(name) || COLOR_TEMP_KELVIN.equals(name) || KELVIN.equals(name)) {
+        if (COLOR_TEMP_KELVIN.equals(name) || KELVIN.equals(name)) {
+          type = nullable(type, "number");
+          unit = nullable(unit, UNIT_KELVIN);
+        } else {
+          type = nullable(type, "mireds");
+          unit = nullable(unit, "mired");
+        }
+      } else if (TRANSITION.equals(name)) {
+        type = nullable(type, "duration_s");
+        unit = nullable(unit, "s");
+      } else if (EFFECT.equals(name)) {
+        type = nullable(type, "enum");
+      }
+    }
+
+    // --- Fan ---
+    else if (FAN.equals(domain)) {
+      if (("set_percentage".equals(service) || "set_speed".equals(service))
+          && PERCENTAGE.equals(name)) {
+        type = nullable(type, "percent");
+        unit = nullable(unit, UNIT_PERCENT);
+      } else if ("set_direction".equals(service) && DIRECTION.equals(name)) {
+        type = nullable(type, "enum");
+      } else if (("set_preset_mode".equals(service) || "set_preset".equals(service))
+          && PRESET_MODE.equals(name)) {
+        type = nullable(type, "enum");
+      }
+    }
+
+    // --- Cover ---
+    else if (COVER.equals(domain)) {
+      if ("set_cover_position".equals(service) && POSITION.equals(name)) {
+        type = nullable(type, "percent");
+        unit = nullable(unit, UNIT_PERCENT);
+      } else if ("set_cover_tilt_position".equals(service) && TILT_POSITION.equals(name)) {
+        type = nullable(type, "percent");
+        unit = nullable(unit, UNIT_PERCENT);
+      }
+    }
+
+    // --- Media Player ---
+    else if (MEDIA_PLAYER.equals(domain)) {
+      if ("volume_set".equals(service) && VOLUME_LEVEL.equals(name)) {
+        type = nullable(type, "percent");
+        unit = nullable(unit, UNIT_PERCENT);
+      } else if ("select_source".equals(service) && SOURCE.equals(name)) {
+        type = nullable(type, "enum");
+      } else if ("select_sound_mode".equals(service) && SOUND_MODE.equals(name)) {
+        type = nullable(type, "enum");
+      }
+    }
+
+    // --- NUMBER (generic) ---
+    else if (NUMBER.equals(domain) && "ser_value".equals(service) && VALUE.equals(name)) {
+      type = nullable(type, "number");
+    }
+
+    if (Objects.equals(type, f.type()) && Objects.equals(unit, f.unit())) return f;
+    return new ServiceField(type, unit, f.required());
+  }
+
+  private static String nullable(String current, String candidate) {
+    return (current == null || current.isBlank()) ? candidate : current;
+  }
+}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/infer/AttributeRules.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/infer/AttributeRules.java
@@ -83,6 +83,27 @@ public final class AttributeRules {
                     FieldKind.NUMBER, unit, null, null, new CapabilityRange(min, max, step))));
   }
 
+  public static AttributeRule numberWithCapsFromKeys(
+      String canonicalName, String unitKey, String minKey, String maxKey, String stepKey) {
+    return state -> {
+      var a = state.attributes();
+      var min = num(a.get(minKey));
+      var max = num(a.get(maxKey));
+      var step = num(a.get(stepKey));
+      var unit = str(a.get(unitKey));
+
+      if (step == null) step = 1.0;
+
+      if (min == null || max == null && unit == null) return Optional.empty();
+
+      return Optional.of(
+          Map.entry(
+              canonicalName,
+              new AttributeDesc(
+                  FieldKind.NUMBER, unit, null, null, new CapabilityRange(min, max, step))));
+    };
+  }
+
   public static AttributeRule numberDescriptor(String canonicalName, String unit) {
     return state ->
         Optional.of(

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/infer/RuleRegistry.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/infer/RuleRegistry.java
@@ -12,8 +12,10 @@ import static io.pulseautomate.map.manifest.util.Names.HaAttr.CURRENT_TILT_POSIT
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.DIRECTION_LIST;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.EFFECT_LIST;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.HVAC_MODES;
+import static io.pulseautomate.map.manifest.util.Names.HaAttr.MAX;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.MAX_MIREDS;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.MAX_TEMP;
+import static io.pulseautomate.map.manifest.util.Names.HaAttr.MIN;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.MIN_MIREDS;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.MIN_TEMP;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.PERCENTAGE;
@@ -22,10 +24,12 @@ import static io.pulseautomate.map.manifest.util.Names.HaAttr.PRESET_MODES;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.SOUND_MODE_LIST;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.SOURCE_LIST;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.SPEED_LIST;
+import static io.pulseautomate.map.manifest.util.Names.HaAttr.STEP;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.SUPPORTED_COLOR_MODES;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.TARGET_TEMP_STEP;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.TEMPERATURE_UNIT;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.TILT_POSITION;
+import static io.pulseautomate.map.manifest.util.Names.HaAttr.UNIT_OF_MEASUREMENT;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.VOLUME_LEVEL;
 
 import java.util.LinkedHashMap;
@@ -91,7 +95,17 @@ public final class RuleRegistry {
             enumFrom(SOURCE, SOURCE_LIST, SOURCE, true),
             enumFrom(SOUND_MODE, SOUND_MODE_LIST, SOUND_MODE, true));
 
-    return new RuleRegistry(createRuleMap(climate, light, fan, cover, media));
+    var number =
+        create(
+            NUMBER,
+            presentIfAny(
+                numberWithCapsFromKeys(VALUE, UNIT_OF_MEASUREMENT, MIN, MAX, STEP),
+                MIN,
+                MAX,
+                STEP,
+                UNIT_OF_MEASUREMENT));
+
+    return new RuleRegistry(createRuleMap(climate, light, fan, cover, media, number));
   }
 
   private static DomainRuleSet create(String domain, AttributeRule... attributeRule) {

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/util/Names.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/util/Names.java
@@ -9,6 +9,7 @@ public final class Names {
     public static final String FAN = "fan";
     public static final String COVER = "cover";
     public static final String MEDIA_PLAYER = "media_player";
+    public static final String NUMBER = "number";
   }
 
   public static final class Attr {
@@ -33,6 +34,8 @@ public final class Names {
     public static final String VOLUME_PCT = "volume_pct";
     public static final String SOURCE = "source";
     public static final String SOUND_MODE = "sound_mode";
+
+    public static final String VALUE = "value";
   }
 
   public static final class HaAttr {
@@ -66,10 +69,39 @@ public final class Names {
     public static final String SOURCE_LIST = "source_list";
     public static final String SOUND_MODE = "sound_mode";
     public static final String SOUND_MODE_LIST = "sound_mode_list";
+
+    public static final String MIN = "min";
+    public static final String MAX = "max";
+    public static final String STEP = "step";
+    public static final String UNIT_OF_MEASUREMENT = "unit_of_measurement";
   }
 
   public static final class ColorMode {
     public static final String HS = "hs";
     public static final String COLOR_TEMP = "color_temp";
+  }
+
+  public static final class SvcField {
+    public static final String TEMPERATURE = "temperature";
+    public static final String HVAC_MODE = "hvac_mode";
+    public static final String PRESET_MODE = "preset_mode";
+
+    public static final String BRIGHTNESS_PCT = "brightness_pct";
+    public static final String COLOR_TEMP = "color_temp";
+    public static final String COLOR_TEMP_KELVIN = "color_temp_kelvin";
+    public static final String KELVIN = "kelvin";
+    public static final String TRANSITION = "transition";
+    public static final String EFFECT = "effect";
+
+    public static final String PERCENTAGE = "percentage";
+    public static final String DIRECTION = "direction";
+    public static final String POSITION = "position";
+    public static final String TILT_POSITION = "tilt_position";
+
+    public static final String VOLUME_LEVEL = "volume_level";
+    public static final String SOURCE = "source";
+    public static final String SOUND_MODE = "sound_mode";
+
+    public static final String VALUE = "value";
   }
 }

--- a/manifest/src/test/java/io/pulseautomate/map/manifest/builder/ManifestBuilderTest.java
+++ b/manifest/src/test/java/io/pulseautomate/map/manifest/builder/ManifestBuilderTest.java
@@ -156,8 +156,7 @@ class ManifestBuilderTest {
     assertThat(s.service()).isEqualTo("set_temperature");
     assertThat(s.fields()).containsKey("temperature");
     assertThat(s.fields().get("temperature").required()).isTrue();
-    // type/unit are intentionally null at this stage (schema-only pass-through)
-    assertThat(s.fields().get("temperature").type()).isNull();
-    assertThat(s.fields().get("temperature").unit()).isNull();
+    assertThat(s.fields().get("temperature").type()).isEqualTo("number");
+    assertThat(s.fields().get("temperature").unit()).isEqualTo(UNIT_CELSIUS_WITH_SYMBOL);
   }
 }


### PR DESCRIPTION
This pull request introduces a new CLI application for managing Pulse Map manifests, including commands for discovery, validation, and statistics, along with supporting infrastructure and tests. It also updates build configuration and improves manifest service field typing.

**New CLI application and commands:**

* Added a new entry point `MapCli` in `app-cli/src/main/java/io/pulseautomate/map/cli/MapCli.java`, providing a CLI with subcommands for `discover`, `validate`, and `stats`.
* Implemented `DiscoverCommand`, `ValidateCommand`, and `StatsCommand` for manifest discovery, validation, and statistics, respectively, in the `commands` package. These commands handle manifest creation from Home Assistant or demo data, manifest/lock validation, and quick stats output. [[1]](diffhunk://#diff-72e0735782280b3955233d92f6c1348bbd95366d7a66643af500d26803b524afR1-R103) [[2]](diffhunk://#diff-e542c5cb52f35780b4c498914f1f17645abddb4a99a965b783876495e5964962R1-R82) [[3]](diffhunk://#diff-a6a928679482ed7278662490fe2300939f70b6eae8553210e1298a848b468165R1-R65)

**Supporting infrastructure:**

* Added `DiscoverRunner` and supporting providers for fetching Home Assistant or demo snapshots, building manifests and lock files, and writing them to disk.
* Added a test for `DiscoverRunner` to verify manifest and lock file generation and reuse of lock data.

**Build configuration updates:**

* Updated `app-cli/build.gradle.kts` to include required dependencies (`ha-client`, Jackson, AssertJ, etc.), changed the main class to `MapCli`, and added GraalVM native configuration for building a native executable.

**Manifest builder improvement:**

* Improved manifest service field typing by applying `ServiceTyping` to Home Assistant services in `ManifestBuilder`.