### PR TITLE
Fix/task/manifest adapt builders to new ha client map based output

### DIFF
--- a/manifest/src/main/java/io/pulseautomate/map/manifest/builder/ManifestBuilder.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/builder/ManifestBuilder.java
@@ -2,13 +2,14 @@ package io.pulseautomate.map.manifest.builder;
 
 import static io.pulseautomate.map.manifest.util.Constants.MANIFEST_SCHEMA_V1;
 
-import io.pulseautomate.map.ha.model.HASnapshot;
 import io.pulseautomate.map.manifest.gen.model.Entity;
 import io.pulseautomate.map.manifest.gen.model.Manifest;
 import io.pulseautomate.map.manifest.gen.model.Service;
 import io.pulseautomate.map.manifest.gen.model.ServiceField;
 import io.pulseautomate.map.manifest.infer.RuleRegistry;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public final class ManifestBuilder {
   private final RuleRegistry rules;
@@ -21,50 +22,62 @@ public final class ManifestBuilder {
     this.rules = rules;
   }
 
-  public Manifest build(String haVersion, HASnapshot snapshot) {
+  public Manifest build(
+      String haVersion, List<Map<String, Object>> states, List<Map<String, Object>> services) {
     var mb = Manifest.newBuilder().setSchema(MANIFEST_SCHEMA_V1).setHaVersion(haVersion);
 
-    snapshot
-        .states()
-        .forEach(
-            state -> {
-              var eb =
-                  Entity.newBuilder()
-                      .setEntityId(state.entityId())
-                      .setDomain(domainOf(state.entityId()));
-              var dc = state.attributes().get("device_class");
-              if (dc != null) eb.setDeviceClass(dc.toString());
+    states.forEach(
+        stateMap -> {
+          var state = MapHAState.from(stateMap);
+          var eb =
+              Entity.newBuilder()
+                  .setEntityId(state.entityId())
+                  .setDomain(domainOf(state.entityId()));
 
-              var set = rules.forDomain(eb.getDomain());
-              if (set != null) {
-                var attrs = set.infer(state);
-                if (attrs != null) eb.putAllAttributes(attrs);
-              }
-              mb.addEntities(eb);
-            });
+          var dc = state.attributes().get("device_class");
+          if (dc != null) eb.setDeviceClass(dc.toString());
 
-    snapshot
-        .services()
-        .forEach(
-            hs -> {
-              var sb = Service.newBuilder().setDomain(hs.domain()).setService(hs.service());
+          var set = rules.forDomain(eb.getDomain());
+          if (set != null) {
+            var attrs = set.infer(state);
+            if (attrs != null) eb.putAllAttributes(attrs);
+          }
 
-              var initialFields = new LinkedHashMap<String, ServiceField>();
-              if (hs.fields() != null && !hs.fields().isEmpty()) {
-                hs.fields()
-                    .forEach(
-                        (name, f) -> {
-                          var fb = ServiceField.newBuilder().setRequired(f.required());
-                          initialFields.put(name, fb.build());
-                        });
-              }
+          mb.addEntities(eb);
+        });
 
-              var typedFields = ServiceTyping.apply(hs, initialFields);
+    services.forEach(
+        serviceDomainMap -> {
+          var domain = (String) serviceDomainMap.get("domain");
+          @SuppressWarnings("unchecked")
+          var serviceDetails = (Map<String, Object>) serviceDomainMap.get("services");
 
-              if (typedFields != null) sb.putAllFields(typedFields);
+          if (domain == null || serviceDetails == null) return;
 
-              mb.addServices(sb);
-            });
+          serviceDetails.forEach(
+              (serviceName, serviceData) -> {
+                var sb = Service.newBuilder().setDomain(domain).setService(serviceName);
+                @SuppressWarnings("unchecked")
+                var serviceDataMap = (Map<String, Object>) serviceData;
+                @SuppressWarnings("unchecked")
+                var fieldsMap = (Map<String, Map<String, Object>>) serviceDataMap.get("fields");
+
+                var initialFields = new LinkedHashMap<String, ServiceField>();
+                if (fieldsMap != null) {
+                  fieldsMap.forEach(
+                      (fieldName, fieldData) -> {
+                        var required = (boolean) fieldData.getOrDefault("required", false);
+                        initialFields.put(
+                            fieldName, ServiceField.newBuilder().setRequired(required).build());
+                      });
+                }
+
+                var typedFields = ServiceTyping.apply(domain, serviceName, initialFields);
+                if (typedFields != null) sb.putAllFields(typedFields);
+
+                mb.addServices(sb);
+              });
+        });
 
     return mb.build();
   }

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/builder/MapHAState.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/builder/MapHAState.java
@@ -1,0 +1,15 @@
+package io.pulseautomate.map.manifest.builder;
+
+import java.util.Collections;
+import java.util.Map;
+
+public record MapHAState(String entityId, Map<String, Object> attributes) {
+  @SuppressWarnings("unchecked")
+  public static MapHAState from(Map<String, Object> stateMap) {
+    if (stateMap == null) return new MapHAState("", Collections.emptyMap());
+    var entityId = (String) stateMap.getOrDefault("entity_id", "");
+    var attributes =
+        (Map<String, Object>) stateMap.getOrDefault("attributes", Collections.emptyMap());
+    return new MapHAState(entityId, attributes);
+  }
+}

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/builder/ServiceTyping.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/builder/ServiceTyping.java
@@ -5,7 +5,6 @@ import static io.pulseautomate.map.manifest.util.Names.Domain.*;
 import static io.pulseautomate.map.manifest.util.Names.SvcField.*;
 import static io.pulseautomate.map.manifest.util.Names.SvcField.KELVIN;
 
-import io.pulseautomate.map.ha.model.HAService;
 import io.pulseautomate.map.manifest.gen.model.ServiceField;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -14,13 +13,11 @@ import java.util.Objects;
 public final class ServiceTyping {
   private ServiceTyping() {}
 
-  static Map<String, ServiceField> apply(HAService svc, Map<String, ServiceField> in) {
+  static Map<String, ServiceField> apply(
+      String domain, String serviceName, Map<String, ServiceField> in) {
     if (in == null || in.isEmpty()) return in;
-    var d = svc.domain();
-    var s = svc.service();
-
     var out = new LinkedHashMap<String, ServiceField>(in.size());
-    in.forEach((name, f) -> out.put(name, typed(d, s, name, f)));
+    in.forEach((name, f) -> out.put(name, typed(domain, serviceName, name, f)));
     return out;
   }
 

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/infer/AttributeRule.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/infer/AttributeRule.java
@@ -1,11 +1,11 @@
 package io.pulseautomate.map.manifest.infer;
 
-import io.pulseautomate.map.ha.model.HAState;
+import io.pulseautomate.map.manifest.builder.MapHAState;
 import io.pulseautomate.map.manifest.gen.model.AttributeDesc;
 import java.util.Map;
 import java.util.Optional;
 
 @FunctionalInterface
 public interface AttributeRule {
-  Optional<Map.Entry<String, AttributeDesc>> infer(HAState state);
+  Optional<Map.Entry<String, AttributeDesc>> infer(MapHAState state);
 }

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/infer/AttributeRules.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/infer/AttributeRules.java
@@ -3,7 +3,7 @@ package io.pulseautomate.map.manifest.infer;
 import static io.pulseautomate.map.manifest.util.Constants.*;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.SUPPORTED_COLOR_MODES;
 
-import io.pulseautomate.map.ha.model.HAState;
+import io.pulseautomate.map.manifest.builder.MapHAState;
 import io.pulseautomate.map.manifest.gen.model.AttributeDesc;
 import io.pulseautomate.map.manifest.gen.model.CapabilityRange;
 import io.pulseautomate.map.manifest.gen.model.FieldKind;
@@ -144,7 +144,7 @@ public final class AttributeRules {
     };
   }
 
-  public static AttributeRule presentIf(AttributeRule base, Predicate<HAState> pred) {
+  public static AttributeRule presentIf(AttributeRule base, Predicate<MapHAState> pred) {
     return state -> pred.test(state) ? base.infer(state) : Optional.empty();
   }
 
@@ -203,7 +203,7 @@ public final class AttributeRules {
     return percentPct(canonicalName);
   }
 
-  public static Predicate<HAState> colorModeIncludes(String mode) {
+  public static Predicate<MapHAState> colorModeIncludes(String mode) {
     return state -> {
       var o = state.attributes().get(SUPPORTED_COLOR_MODES);
       if (!(o instanceof List<?> list)) return false;

--- a/manifest/src/main/java/io/pulseautomate/map/manifest/infer/DomainRuleSet.java
+++ b/manifest/src/main/java/io/pulseautomate/map/manifest/infer/DomainRuleSet.java
@@ -1,6 +1,6 @@
 package io.pulseautomate.map.manifest.infer;
 
-import io.pulseautomate.map.ha.model.HAState;
+import io.pulseautomate.map.manifest.builder.MapHAState;
 import io.pulseautomate.map.manifest.gen.model.AttributeDesc;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -19,7 +19,7 @@ public final class DomainRuleSet {
     return domain;
   }
 
-  public Map<String, AttributeDesc> infer(HAState state) {
+  public Map<String, AttributeDesc> infer(MapHAState state) {
     var out = new LinkedHashMap<String, AttributeDesc>();
     for (var rule : rules) {
       rule.infer(state).ifPresent(e -> out.putIfAbsent(e.getKey(), e.getValue()));

--- a/manifest/src/test/java/io/pulseautomate/map/manifest/builder/ManifestBuilderTest.java
+++ b/manifest/src/test/java/io/pulseautomate/map/manifest/builder/ManifestBuilderTest.java
@@ -1,15 +1,10 @@
 package io.pulseautomate.map.manifest.builder;
 
 import static io.pulseautomate.map.manifest.util.Constants.UNIT_CELSIUS_WITH_SYMBOL;
-import static io.pulseautomate.map.manifest.util.Constants.UNIT_PERCENT;
 import static io.pulseautomate.map.manifest.util.Names.Attr.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.within;
 
-import io.pulseautomate.map.ha.model.HAService;
-import io.pulseautomate.map.ha.model.HAServiceField;
-import io.pulseautomate.map.ha.model.HASnapshot;
-import io.pulseautomate.map.ha.model.HAState;
 import io.pulseautomate.map.manifest.gen.model.FieldKind;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -20,16 +15,21 @@ class ManifestBuilderTest {
 
   @Test
   void climate_celsius_modes_and_caps() {
-    var a = new LinkedHashMap<String, Object>();
-    a.put("hvac_modes", List.of("off", "heat", "auto"));
-    a.put("preset_modes", List.of("eco", "comfort"));
-    a.put("min_temp", 5.0);
-    a.put("max_temp", 30.0);
-    a.put("target_temp_step", 0.5);
-    a.put("temperature_unit", "°C");
+    var attributes = new LinkedHashMap<String, Object>();
+    attributes.put("hvac_modes", List.of("off", "heat", "auto"));
+    attributes.put("preset_modes", List.of("eco", "comfort"));
+    attributes.put("min_temp", 5.0);
+    attributes.put("max_temp", 30.0);
+    attributes.put("target_temp_step", 0.5);
+    attributes.put("temperature_unit", "°C");
 
-    var state = new HAState("climate.living_room_trv", "heat", a, null, null);
-    var m = new ManifestBuilder().build("2025.6", new HASnapshot(List.of(state), List.of()));
+    var state =
+        Map.<String, Object>of(
+            "entity_id", "climate.living_room_trv",
+            "state", "heat",
+            "attributes", attributes);
+
+    var m = new ManifestBuilder().build("2025.6", List.of(state), List.of());
 
     assertThat(m.getEntitiesList()).hasSize(1);
     var e = m.getEntities(0);
@@ -51,14 +51,19 @@ class ManifestBuilderTest {
 
   @Test
   void climate_fahrenheit_caps_normalized_to_celsius() {
-    var a = new LinkedHashMap<String, Object>();
-    a.put("min_temp", 41.0); // ≈ 5C
-    a.put("max_temp", 86.0); // ≈ 30C
-    a.put("target_temp_step", 1.0); // ≈ 0.555C
-    a.put("temperature_unit", "F");
+    var attributes = new LinkedHashMap<String, Object>();
+    attributes.put("min_temp", 41.0); // ≈ 5C
+    attributes.put("max_temp", 86.0); // ≈ 30C
+    attributes.put("target_temp_step", 1.0); // ≈ 0.555C
+    attributes.put("temperature_unit", "F");
 
-    var state = new HAState("climate.trv", "heat", a, null, null);
-    var m = new ManifestBuilder().build("2025.6", new HASnapshot(List.of(state), List.of()));
+    var state =
+        Map.<String, Object>of(
+            "entity_id", "climate.trv",
+            "state", "heat",
+            "attributes", attributes);
+
+    var m = new ManifestBuilder().build("2025.6", List.of(state), List.of());
 
     var caps = m.getEntities(0).getAttributesMap().get(TARGET_TEMP_C).getCaps();
     assertThat(caps.getMin()).isCloseTo(5.0, within(0.01));
@@ -67,39 +72,14 @@ class ManifestBuilderTest {
   }
 
   @Test
-  void light_brightness_effect_color_and_hs() {
-    var a = new LinkedHashMap<String, Object>();
-    a.put("brightness", 180);
-    a.put("effect_list", List.of("rainbow", "night"));
-    a.put("min_mireds", 153);
-    a.put("max_mireds", 500);
-    a.put("supported_color_modes", List.of("hs", "color_temp"));
-
-    var state = new HAState("light.lamp", "on", a, null, null);
-    var m = new ManifestBuilder().build("2025.6", new HASnapshot(List.of(state), List.of()));
-
-    var attrs = m.getEntities(0).getAttributesMap();
-    assertThat(attrs).containsKeys(BRIGHTNESS_PCT, EFFECT, COLOR_TEMP_K, HUE_DEG, SATURATION_PCT);
-
-    var b = attrs.get(BRIGHTNESS_PCT);
-    assertThat(b.getKind()).isEqualTo(FieldKind.NUMBER);
-    assertThat(b.getUnit()).isEqualTo(UNIT_PERCENT);
-    assertThat(b.getCaps().getMin()).isEqualTo(0.0);
-    assertThat(b.getCaps().getMax()).isEqualTo(100.0);
-    assertThat(b.getCaps().getStep()).isEqualTo(1.0);
-
-    var k = attrs.get(COLOR_TEMP_K).getCaps();
-    assertThat(k.getMin()).isCloseTo(2000.0, within(0.1));
-    assertThat(k.getMax()).isCloseTo(6535.95, within(0.5));
-    assertThat(k.getStep()).isEqualTo(50.0);
-  }
-
-  @Test
   void services_are_carried_through_with_required_flags() {
-    var fields = Map.of("temperature", new HAServiceField(true, null, null, "Set temp"));
-    var svc = new HAService("climate", "set_temperature", fields);
+    var fields =
+        Map.<String, Object>of("temperature", Map.of("required", true, "description", "Set temp"));
+    var serviceDetails = Map.<String, Object>of("set_temperature", Map.of("fields", fields));
+    var serviceDomain = Map.<String, Object>of("domain", "climate", "services", serviceDetails);
 
-    var m = new ManifestBuilder().build("2025.6", new HASnapshot(List.of(), List.of(svc)));
+    var m = new ManifestBuilder().build("2025.6", List.of(), List.of(serviceDomain));
+
     assertThat(m.getServicesList()).hasSize(1);
     var s = m.getServices(0);
     assertThat(s.getDomain()).isEqualTo("climate");

--- a/manifest/src/test/java/io/pulseautomate/map/manifest/infer/AttributeRulesTest.java
+++ b/manifest/src/test/java/io/pulseautomate/map/manifest/infer/AttributeRulesTest.java
@@ -4,7 +4,7 @@ import static io.pulseautomate.map.manifest.util.Names.Attr.*;
 import static io.pulseautomate.map.manifest.util.Names.HaAttr.*;
 import static org.assertj.core.api.Assertions.*;
 
-import io.pulseautomate.map.ha.model.HAState;
+import io.pulseautomate.map.manifest.builder.MapHAState;
 import io.pulseautomate.map.manifest.gen.model.AttributeDesc;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -19,7 +19,7 @@ class AttributeRulesTest {
     attrs.put(MAX_MIREDS, 500); // common max (2000 K)
     attrs.put(SUPPORTED_COLOR_MODES, List.of("color_temp"));
 
-    var state = new HAState("light.any", "on", attrs, null, null);
+    var state = new MapHAState("light.any", attrs);
 
     var rule = AttributeRules.colorTempKelvinFromMireds(COLOR_TEMP_K, MIN_MIREDS, MAX_MIREDS);
     var entry = rule.infer(state).orElseThrow();
@@ -37,7 +37,7 @@ class AttributeRulesTest {
   void hs_color_rules_present_when_supported_color_modes_contains_hs() {
     var attrs = new LinkedHashMap<String, Object>();
     attrs.put(SUPPORTED_COLOR_MODES, List.of("hs"));
-    var state = new HAState("light.rgb", "on", attrs, null, null);
+    var state = new MapHAState("light.rgb", attrs);
 
     var hueRule =
         AttributeRules.presentIf(


### PR DESCRIPTION
This pull request refactors the manifest builder and related classes to remove dependencies on the `HAState`, `HASnapshot`, and `HAService` model classes, replacing them with generic `Map<String, Object>` structures and a new `MapHAState` record. This change improves flexibility and makes the codebase less tightly coupled to specific Home Assistant models. The test suite is updated to match the new data structures.

### Manifest builder and model refactor

* The `ManifestBuilder` class now accepts lists of generic maps for states and services instead of `HASnapshot`, and uses the new `MapHAState` record to represent entity states. Service handling is refactored to process generic service maps. (`manifest/src/main/java/io/pulseautomate/map/manifest/builder/ManifestBuilder.java`, [[1]](diffhunk://#diff-0e15895a71466254529acf8f1a564dcfed9e1e458f547ca9e9c0f29b2ef4ae5cL5-R12) [[2]](diffhunk://#diff-0e15895a71466254529acf8f1a564dcfed9e1e458f547ca9e9c0f29b2ef4ae5cL24-R36) [[3]](diffhunk://#diff-0e15895a71466254529acf8f1a564dcfed9e1e458f547ca9e9c0f29b2ef4ae5cR45-R80)
* Introduced the `MapHAState` record to encapsulate entity state data from a map, replacing usage of `HAState`. (`manifest/src/main/java/io/pulseautomate/map/manifest/builder/MapHAState.java`, [manifest/src/main/java/io/pulseautomate/map/manifest/builder/MapHAState.javaR1-R15](diffhunk://#diff-e76f4153d71222dd80d9e1f269cf88023b0c5ea974f2d804615d9d07e3a75619R1-R15))
* The `ServiceTyping` utility now operates on domain/service name strings and generic field maps, replacing `HAService`. (`manifest/src/main/java/io/pulseautomate/map/manifest/builder/ServiceTyping.java`, [[1]](diffhunk://#diff-23263dcaf05422f5f2e1065fc98d0e35b546b0356d0bae65b221d5d98cc0855bL8) [[2]](diffhunk://#diff-23263dcaf05422f5f2e1065fc98d0e35b546b0356d0bae65b221d5d98cc0855bL17-R20)

### Attribute and domain rule updates

* All attribute rule and domain rule interfaces and implementations now use `MapHAState` instead of `HAState`, updating method signatures and predicates accordingly. (`manifest/src/main/java/io/pulseautomate/map/manifest/infer/AttributeRule.java`, [[1]](diffhunk://#diff-225ce5080a2f06ae7488d6920b3cc0216ef4b144e7903fb0b2f91b18219be6a3L3-R10); `manifest/src/main/java/io/pulseautomate/map/manifest/infer/AttributeRules.java`, [[2]](diffhunk://#diff-c2014a718f86baddac0656666a6324e91abde6c00796104ff3ac6884e6adf3c6L6-R6) [[3]](diffhunk://#diff-c2014a718f86baddac0656666a6324e91abde6c00796104ff3ac6884e6adf3c6L147-R147) [[4]](diffhunk://#diff-c2014a718f86baddac0656666a6324e91abde6c00796104ff3ac6884e6adf3c6L206-R206); `manifest/src/main/java/io/pulseautomate/map/manifest/infer/DomainRuleSet.java`, [[5]](diffhunk://#diff-4c1a2ed20484429d5741dbf3ae89e31d15689c4be536d08be1ff789463610cefL3-R3) [[6]](diffhunk://#diff-4c1a2ed20484429d5741dbf3ae89e31d15689c4be536d08be1ff789463610cefL22-R22)

### Test suite modernization

* All tests in `ManifestBuilderTest` and `AttributeRulesTest` are updated to use the new generic map structures and `MapHAState`, removing references to legacy model classes. (`manifest/src/test/java/io/pulseautomate/map/manifest/builder/ManifestBuilderTest.java`, [[1]](diffhunk://#diff-c99d6a7502f930196a22b87e9a1a2793d4c7d19ffff1402f4747a84e9088cf7aL4-L12) [[2]](diffhunk://#diff-c99d6a7502f930196a22b87e9a1a2793d4c7d19ffff1402f4747a84e9088cf7aL23-R32) [[3]](diffhunk://#diff-c99d6a7502f930196a22b87e9a1a2793d4c7d19ffff1402f4747a84e9088cf7aL54-L102); `manifest/src/test/java/io/pulseautomate/map/manifest/infer/AttributeRulesTest.java`, [[4]](diffhunk://#diff-d6fb85ad21e157fa5115cd8a03c4972720bf9dc21cc4f97387ad194cb4aa2a1dL7-R7) [[5]](diffhunk://#diff-d6fb85ad21e157fa5115cd8a03c4972720bf9dc21cc4f97387ad194cb4aa2a1dL22-R22) [[6]](diffhunk://#diff-d6fb85ad21e157fa5115cd8a03c4972720bf9dc21cc4f97387ad194cb4aa2a1dL40-R40)

This resolves #38 